### PR TITLE
remove possibility to set bfield (only tke from lcgeo geometry info)

### DIFF
--- a/source/include/vertexInfo.h
+++ b/source/include/vertexInfo.h
@@ -71,7 +71,6 @@ class vertexInfo{
     for ( int i=0; i<3; i++) _ipSize[i]=xyz[i];
   }
 
-  void setBField(float field) {_bField=field;}
   float getBField() {return _bField;}
 
   void addTrack( EVENT::Track* trk );


### PR DESCRIPTION
force bfield info to be taken from dd4hep info, remove ability to set it by hand.
less chance of screw-ups...?